### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/common/platform_win32.cpp
+++ b/common/platform_win32.cpp
@@ -162,8 +162,10 @@ bool IsFile(const string& sPath)
 	if (hFind == INVALID_HANDLE_VALUE)
 		return false;
 
-	if (fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
+	if (fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
+		FindClose(hFind);
 		return false;
+	}
 
 	return true;
 }
@@ -181,8 +183,10 @@ bool IsDirectory(const string& sPath)
 	if (hFind == INVALID_HANDLE_VALUE)
 		return false;
 
-	if (fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
+	if (fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
+		FindClose(hFind);
 		return true;
+	}
 
 	return false;
 }

--- a/glfw-2.7.9/lib/tga.c
+++ b/glfw-2.7.9/lib/tga.c
@@ -306,8 +306,7 @@ int _glfwReadTGA( _GLFWstream *s, GLFWimage *img, int flags )
         swapy = 0;
         break;
     }
-    if( (swapy && !(flags & GLFW_ORIGIN_UL_BIT)) ||
-        (!swapy && (flags & GLFW_ORIGIN_UL_BIT)) )
+    if( swapy != (flags & GLFW_ORIGIN_UL_BIT))
     {
         src = pix;
         dst = &pix[ (h.height-1)*h.width*bpp ];

--- a/math/spline.h
+++ b/math/spline.h
@@ -5,7 +5,7 @@
 struct CubicSpline
 {
 	vec3 m_points[SPLINE_POINTS];
-	vec3 m_coeffs[SPLINE_POINTS-1][4];
+	vec3 m_coeffs[SPLINE_POINTS][4];
 	float m_lengths[SPLINE_POINTS - 1];
 
 	// Spline construction, Burden & Faires - Numerical Analysis 9th, algorithm 3.4
@@ -15,7 +15,7 @@ struct CubicSpline
 
 		vec3 a[SPLINE_POINTS];
 		for (int i = 1; i <= n - 1; i++)
-			a[i] = 3 * ((m_points[i + 1] - 2*m_points[i] + m_points[i - 1]));
+			a[i] = 3 * (m_points[i + 1] - 2*m_points[i] + m_points[i - 1]);
 
 		float l[SPLINE_POINTS];
 		float mu[SPLINE_POINTS];

--- a/renderer/application.cpp
+++ b/renderer/application.cpp
@@ -98,7 +98,7 @@ bool CApplication::OpenWindow(size_t iWidth, size_t iHeight, bool bFullscreen, b
 		return false;
 	}
 
-	glfwSetWindowTitle((char*)L"Math for Game Developers");
+	glfwSetWindowTitle("Math for Game Developers");
 
 	int iScreenWidth;
 	int iScreenHeight;

--- a/renderer/image_read.cpp
+++ b/renderer/image_read.cpp
@@ -2967,7 +2967,10 @@ static stbi_uc *tga_load(stbi *s, int *x, int *y, int *comp, int req_comp)
       skip(s, tga_palette_start );
       //   load the palette
       tga_palette = (unsigned char*)malloc( tga_palette_len * tga_palette_bits / 8 );
-      if (!tga_palette) return epuc("outofmem", "Out of memory");
+	  if (!tga_palette) {
+		  free(tga_data);
+		  return epuc("outofmem", "Out of memory");
+	  }
       if (!getn(s, tga_palette, tga_palette_len * tga_palette_bits / 8 )) {
          free(tga_data);
          free(tga_palette);
@@ -3492,6 +3495,8 @@ static stbi_uc *pic_load(stbi *s,int *px,int *py,int *comp,int req_comp)
 
    // intermediate buffer is RGBA
    result = (stbi_uc *) malloc(x*y*4);
+   if (!result) return epuc("cannot allocate", "cannot allocate memory");
+
    memset(result, 0xff, x*y*4);
 
    if (!pic_load2(s,x,y,comp, result)) {


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

[V542](https://www.viva64.com/en/w/v542/) Consider inspecting an odd type cast: 'wchar_t *' to 'char *'. application.cpp 101

m_coeffs changed size to [SPLINE_POINTS][4];
[V557](https://www.viva64.com/en/w/v557/) Array overrun is possible. The 'n' index is pointing beyond array bound. spline.h 27
[V557](https://www.viva64.com/en/w/v557/) Array overrun is possible. The value of 'i' index could reach 15. spline.h 37
[V557](https://www.viva64.com/en/w/v557/) Array overrun is possible. The value of 'j + 1' index could reach 15. spline.h 41
[V557](https://www.viva64.com/en/w/v557/) Array overrun is possible. The value of 'j + 1' index could reach 15. spline.h 42
[V557](https://www.viva64.com/en/w/v557/) Array overrun is possible. The 'ArcLengthIntegrandSingleSpline' function processes value '15'. Inspect the first argument. Check lines: 78, 92. spline.h 78

[V575](https://www.viva64.com/en/w/v575/) The potential null pointer is passed into 'memset' function. Inspect the first argument. image_read.cpp 3495
[V592](https://www.viva64.com/en/w/v592/) The expression was enclosed by parentheses twice: ((expression)). One pair of parentheses is unnecessary or misprint is present. spline.h 18
[V728](https://www.viva64.com/en/w/v728/) An excessive check can be simplified. The '(A && !B) || (!A && B)' expression is equivalent to the 'bool(A) != bool(B)' expression. tga.c 309
[V773](https://www.viva64.com/en/w/v773/) The function was exited without releasing the 'hFind' handle. A resource leak is possible. platform_win32.cpp 166, 185V773 The function was exited without releasing the 'tga_data' pointer. A memory leak is possible. image_read.cpp 2970